### PR TITLE
Change UIBarButtonItemStyleBordered to UIBarButtonItemStylePlain

### DIFF
--- a/MidtransKit/MidtransKit/VTDetailedTitleController.m
+++ b/MidtransKit/MidtransKit/VTDetailedTitleController.m
@@ -49,7 +49,7 @@
     
     [self.navigationItem setTitleView:headerView];
     
-    [self.navigationItem setRightBarButtonItem:[[UIBarButtonItem alloc] initWithTitle:@"          " style:UIBarButtonItemStyleBordered target:nil action:nil]];
+    [self.navigationItem setRightBarButtonItem:[[UIBarButtonItem alloc] initWithTitle:@"          " style:UIBarButtonItemStylePlain target:nil action:nil]];
     
     self.navigationItem.titleView.frame = CGRectMake(0, 20, 500, 44);
 


### PR DESCRIPTION
to remove warning, because it's deprecated on iOS 7 deployment