### PR TITLE
mob-1600-fix-mixpanel-data

### DIFF
--- a/MidtransCoreKit/MidtransCoreKit/MidtransConstant.h
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransConstant.h
@@ -141,8 +141,6 @@ static NSString *const MIDTRANS_TRACKING_APP_TRANSACTION_ERROR = @"Transaction F
 
 static NSString *const MIDTRANS_TRACKING_MERCHANT_ID = @"merchant_id";
 static NSString *const MIDTRANS_TRACKING_ENABLED_PAYMENTS = @"enabled_payments";
-static NSString *const MIDTRANS_TRACKING_INSTALLMENT_AVAILABLE = @"installment_available";
-static NSString *const MIDTRANS_TRACKING_INSTALLMENT_REQUIRED = @"installment_required";
 
 static NSString *const MIDTRANS_CORE_SNAP_MERCHANT_SERVER_CHARGE = @"charge";
 static NSString *const MIDTRANS_CORE_SNAP_PARAMETER_TRANSACTION_DETAILS = @"transaction_details";

--- a/MidtransKit/MidtransKit/classes/MidtransSavedCardController.m
+++ b/MidtransKit/MidtransKit/classes/MidtransSavedCardController.m
@@ -147,13 +147,10 @@
 }
 
 - (void)performOneClickWithCard:(MidtransMaskedCreditCard *)card {
-    id available = [[NSUserDefaults standardUserDefaults] objectForKey:MIDTRANS_TRACKING_INSTALLMENT_AVAILABLE];
-    id required = [[NSUserDefaults standardUserDefaults] objectForKey:MIDTRANS_TRACKING_INSTALLMENT_REQUIRED];
-    NSMutableDictionary *additionalData = [NSMutableDictionary dictionaryWithDictionary:@{@"installment available": available, @"installment required": required}];
     if (self.responsePayment.transactionDetails.orderId) {
-        [additionalData addEntriesFromDictionary:@{@"order id":self.responsePayment.transactionDetails.orderId}];
+        [[SNPUITrackingManager shared] trackEventName:@"btn confirm payment" additionalParameters:@{@"order id":self.responsePayment.transactionDetails.orderId}];
     }
-    [[SNPUITrackingManager shared] trackEventName:@"btn confirm payment" additionalParameters:additionalData];
+    [[SNPUITrackingManager shared] trackEventName:@"btn confirm payment"];
     VTConfirmPaymentController *vc = [[VTConfirmPaymentController alloc] initWithCardNumber:card.maskedNumber
                                                grossAmount:self.token.transactionDetails.grossAmount];
     

--- a/MidtransKit/MidtransKit/classes/VTPaymentStatusController.m
+++ b/MidtransKit/MidtransKit/classes/VTPaymentStatusController.m
@@ -106,10 +106,7 @@ typedef NS_ENUM(NSUInteger, SNPStatusType) {
             }
             
             case SNPStatusTypeSuccess: {
-                id available = [[NSUserDefaults standardUserDefaults] objectForKey:MIDTRANS_TRACKING_INSTALLMENT_AVAILABLE];
-                id required = [[NSUserDefaults standardUserDefaults] objectForKey:MIDTRANS_TRACKING_INSTALLMENT_REQUIRED];
-                [additionalData addEntriesFromDictionary:@{@"installment available": available, @"installment required": required}];
-                [[SNPUITrackingManager shared] trackEventName:@"pg success" additionalParameters:additionalData];
+                [[SNPUITrackingManager shared] trackEventName:@"pg success"];
                 self.title = [VTClassHelper getTranslationFromAppBundleForString:@"payment.success"];
                 
                 self.statusIconView.image = [UIImage imageNamed:@"check" inBundle:VTBundle compatibleWithTraitCollection:nil];


### PR DESCRIPTION
remove this as we no longer use user defaults to store installment data, instead we send it directly on view did load
pls review @vanbungkring 