### PR TITLE
mob-1660 fix promo gross in thank you page, correcting amount from transaction result

### DIFF
--- a/MidtransKit/MidtransKit/classes/VTPaymentStatusController.m
+++ b/MidtransKit/MidtransKit/classes/VTPaymentStatusController.m
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSUInteger, SNPStatusType) {
     }
     
     MidtransTransactionDetails *trxDetail = self.token.transactionDetails;
-    self.amountLabel.text = trxDetail.grossAmount.formattedCurrencyNumber;
+    self.amountLabel.text = self.result.grossAmount.formattedCurrencyNumber;
     self.orderIdLabel.text = trxDetail.orderId;
     self.paymentTypeLabel.text = self.paymentMethod.title;
     


### PR DESCRIPTION
 i just change the source from `transactionDetail` to `result`
pls review if this is ok @vanbungkring 