### PR TITLE
fix one click-two click add card when token storage enabled no

### DIFF
--- a/MidtransKit/MidtransKit/classes/MidtransSavedCardController.m
+++ b/MidtransKit/MidtransKit/classes/MidtransSavedCardController.m
@@ -148,7 +148,11 @@
                                                                                        paymentMethodName:self.paymentMethod
                                                                                        andCreditCardData:self.creditCard
                                                                             andCompleteResponseOfPayment:self.responsePayment];
-    vc.currentMaskedCards = nil;
+    if ([[MidtransCreditCardConfig shared] paymentType] == MTCreditCardPaymentTypeOneclick && [[MidtransCreditCardConfig shared] tokenStorageEnabled] == NO) {
+        vc.currentMaskedCards = nil;
+    } else {
+        vc.currentMaskedCards = self.cards;
+    }
     [self.navigationController pushViewController:vc animated:YES];
 }
 


### PR DESCRIPTION
@vanbungkring @femmerling
