### PR TITLE
Bugfix/mob 1671 change idr to rp in ui

### DIFF
--- a/MidtransCoreKit/MidtransCoreKit/MidtransHelper.h
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransHelper.h
@@ -27,6 +27,10 @@ extern NSString *const MidtransMaskedCardsUpdated;
 + (NSString *)randomWithLength:(NSUInteger)length;
 @end
 
+@interface NSNumber (format)
+- (NSString *)roundingWithoutCurrency;
+@end
+
 @interface UIApplication (utilities)
 + (UIViewController *)rootViewController;
 @end

--- a/MidtransCoreKit/MidtransCoreKit/MidtransHelper.m
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransHelper.m
@@ -7,6 +7,7 @@
 //
 
 #import "MidtransHelper.h"
+#import "MidtransConfig.h"
 
 NSString *const MIdtransMaskedCardsUpdated = @"vt_masked_cards_updated";
 NSString *const MIDTRANS_CORE_CURRENCY_IDR = @"IDR";
@@ -76,6 +77,16 @@ NSString *const MIDTRANS_CORE_CURRENCY_SGD = @"SGD";
         [randomString appendFormat: @"%C", [letters characterAtIndex: arc4random_uniform((int)[letters length])]];
     }
     return randomString;
+}
+
+@end
+
+@implementation NSNumber (format)
+
+- (NSString *)roundingWithoutCurrency {
+    NSNumberFormatter *currencyFormatter = [NSNumberFormatter multiCurrencyFormatter:CONFIG.currency];
+    currencyFormatter.numberStyle = NSNumberFormatterNoStyle;
+    return [currencyFormatter stringFromNumber:self];
 }
 
 @end

--- a/MidtransCoreKit/MidtransCoreKit/MidtransHelper.m
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransHelper.m
@@ -160,16 +160,17 @@ NSString *const MIDTRANS_CORE_CURRENCY_SGD = @"SGD";
 
 + (NSNumberFormatter *)multiCurrencyFormatter:(MidtransCurrency)currency {
     NSNumberFormatter *currencyFormatter = [MidtransHelper indonesianCurrencyFormatter];
-    currencyFormatter.numberStyle = NSNumberFormatterCurrencyISOCodeStyle;
     currencyFormatter.paddingPosition = NSNumberFormatterPadAfterPrefix;
     if (currency == MidtransCurrencySGD) {
         currencyFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_SG"];
+        currencyFormatter.numberStyle = NSNumberFormatterCurrencyISOCodeStyle;
         currencyFormatter.minimumFractionDigits = 2;
         currencyFormatter.roundingMode = NSNumberFormatterRoundHalfEven;
     }
     else {
         //  by default set to indonesian
         currencyFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"id_ID"];
+        currencyFormatter.numberStyle = NSNumberFormatterCurrencyStyle;
         currencyFormatter.minimumFractionDigits = 0;
         currencyFormatter.roundingMode = NSNumberFormatterRoundDown;
     }

--- a/MidtransCoreKit/MidtransCoreKit/MidtransMandiriClickpayHelper.m
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransMandiriClickpayHelper.m
@@ -7,6 +7,7 @@
 //
 
 #import "MidtransMandiriClickpayHelper.h"
+#import "MidtransHelper.h"
 
 @implementation MidtransMandiriClickpayHelper
 
@@ -25,7 +26,7 @@
 }
 
 + (NSString *_Nonnull)generateInput2FromGrossAmount:(NSNumber *_Nonnull)grossAmount {
-    return [grossAmount stringValue];
+    return [grossAmount roundingWithoutCurrency];
 }
 
 + (NSString *_Nonnull)generateInput3 {

--- a/MidtransDemo/MidtransDemo/MDOptionsViewController.m
+++ b/MidtransDemo/MidtransDemo/MDOptionsViewController.m
@@ -91,8 +91,9 @@
     ///////////
     //currency
     NSString *idr = [MidtransHelper stringFromCurrency:MidtransCurrencyIDR];
+    NSString *rp = @"Rp";
     NSString *sgd = [MidtransHelper stringFromCurrency:MidtransCurrencySGD];
-    options = @[[MDOption optionGeneralWithName:idr value:idr],
+    options = @[[MDOption optionGeneralWithName:rp value:idr],
                 [MDOption optionGeneralWithName:sgd value:sgd]];
     MDOptionView *optCurrency = [MDOptionView viewWithIcon:[UIImage imageNamed:@"dc_multicurrency"]
                                                  titleTemplate:@"Currency %@"

--- a/MidtransDemo/MidtransDemo/MDOrderViewController.m
+++ b/MidtransDemo/MidtransDemo/MDOrderViewController.m
@@ -38,7 +38,7 @@
     [super viewDidLoad];
     
     self.totalAmount = @(10000.55);
-    NSString *formattedPrice = [self formatISOCurrencyNumber:self.totalAmount];
+    NSString *formattedPrice = [self formattedISOCurrencyNumber:self.totalAmount];
     self.totalAmountLabel.text = self.pricePerItemLabel.text = formattedPrice;
     [self.payButton setTitle:[NSString stringWithFormat:@"Pay %@", formattedPrice] forState:UIControlStateNormal];
     self.emailTextField.backgroundColor = [UIColor colorWithRed:0.93 green:0.93 blue:0.93 alpha:1.0];;
@@ -266,7 +266,7 @@
     [self.navigationController pushViewController:addAddressVC animated:YES];
 }
 
-- (NSString *)formatISOCurrencyNumber:(NSNumber *)number {
+- (NSString *)formattedISOCurrencyNumber:(NSNumber *)number {
     NSNumberFormatter *currencyFormatter = [NSNumberFormatter multiCurrencyFormatter:CONFIG.currency];
     currencyFormatter.formatWidth = 0;
     NSInteger count = [[currencyFormatter stringFromNumber:number] length];

--- a/MidtransDemo/MidtransDemo/MDProductViewController.m
+++ b/MidtransDemo/MidtransDemo/MDProductViewController.m
@@ -34,7 +34,7 @@ UICollectionViewDelegateFlowLayout
     CONFIG.currency = [MidtransHelper currencyFromString:[MDOptionManager shared].currencyOption.value];
     self.title = @"Product Detail";
     NSNumber *price = @(10000.55);
-    self.priceLabel.text = [self formatISOCurrencyNumber:price];
+    self.priceLabel.text = [self formattedISOCurrencyNumber:price];
     self.navigationItem.backBarButtonItem =
     [[UIBarButtonItem alloc] initWithTitle:@""
                                      style:UIBarButtonItemStylePlain
@@ -69,7 +69,7 @@ UICollectionViewDelegateFlowLayout
         self.pageControl.currentPageIndicatorTintColor = [UIColor mdThemeColor];
     });
 }
-- (NSString *)formatISOCurrencyNumber:(NSNumber *)number {
+- (NSString *)formattedISOCurrencyNumber:(NSNumber *)number {
     NSNumberFormatter *currencyFormatter = [NSNumberFormatter multiCurrencyFormatter:CONFIG.currency];
     currencyFormatter.formatWidth = 0;
     NSInteger count = [[currencyFormatter stringFromNumber:number] length];


### PR DESCRIPTION
@vanbungkring 
@femmerling
pls review
changing IDR to Rp is done through `currencyFormatter.numberStyle = NSNumberFormatterCurrencyStyle` line
`roundingWithoutCurrency` is to handle mandiri clickpay input 2 cus we want no currency there but prevent decimal on indonesian.
rename/refactor some method.