### PR TITLE
[CHEC-1030] Add Privacy Manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ xcuserdata/
 DerivedData/
 build/
 fabric_config.txt
+MidtransCoreKit/MidtransCoreKit.xcframework
+MidtransKit/MidtransKit.xcframework

--- a/MidtransCoreKit.podspec
+++ b/MidtransCoreKit.podspec
@@ -1,4 +1,4 @@
-Pod::Spec.new do |s|
+ Pod::Spec.new do |s|
 
 s.name             = "MidtransCoreKit"
 s.version          = "1.24.1"
@@ -7,7 +7,9 @@ s.homepage         = "https://veritrans.co.id/"
 s.license          = 'MIT'
 s.author           = { "veritrans" => "dev@veritrans.co.id" }
 s.source           = { :git => 'https://github.com/veritrans/Veritrans-ios-sdk.git', :tag => s.version}
-s.platform     = :ios, '9.0'
+s.platform     = :ios, '12.0'
+s.ios.deployment_target = '12.0'
+s.resource_bundles = {'MidtransCoreKit' => ['MidtransCoreKit/PrivacyInfo.xcprivacy']}
 s.requires_arc = true
 s.source_files = 'MidtransCoreKit/MidtransCoreKit/**/*.{h,m}'
 s.frameworks    = 'UIKit', 'Foundation'

--- a/MidtransCoreKit.podspec
+++ b/MidtransCoreKit.podspec
@@ -1,4 +1,4 @@
- Pod::Spec.new do |s|
+Pod::Spec.new do |s|
 
 s.name             = "MidtransCoreKit"
 s.version          = "1.24.1"

--- a/MidtransCoreKit.podspec
+++ b/MidtransCoreKit.podspec
@@ -7,8 +7,7 @@ s.homepage         = "https://veritrans.co.id/"
 s.license          = 'MIT'
 s.author           = { "veritrans" => "dev@veritrans.co.id" }
 s.source           = { :git => 'https://github.com/veritrans/Veritrans-ios-sdk.git', :tag => s.version}
-s.platform     = :ios, '12.0'
-s.ios.deployment_target = '12.0'
+s.platform     = :ios, '9.0'
 s.resource_bundles = {'MidtransCoreKit' => ['MidtransCoreKit/PrivacyInfo.xcprivacy']}
 s.requires_arc = true
 s.source_files = 'MidtransCoreKit/MidtransCoreKit/**/*.{h,m}'

--- a/MidtransCoreKit/MidtransCoreKit.xcodeproj/project.pbxproj
+++ b/MidtransCoreKit/MidtransCoreKit.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		0CB8B7C8206B55C10067A0B8 /* MidtransPromoPromos.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CB8B7BB206B558D0067A0B8 /* MidtransPromoPromos.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0CB8B7C9206B55C10067A0B8 /* MidtransPromoResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CB8B7BD206B558D0067A0B8 /* MidtransPromoResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D85847D2111C52500899462 /* MidtransCoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5CDEC8A1E9340CA0032DC3B /* MidtransCoreKit.framework */; };
+		DD100F392BD635F800930FB3 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DD100F382BD635F800930FB3 /* PrivacyInfo.xcprivacy */; };
 		DD1F2A50218AD29100D73039 /* MIDUrlHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1F2A4E218AD29100D73039 /* MIDUrlHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD1F2A51218AD29100D73039 /* MIDUrlHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1F2A4E218AD29100D73039 /* MIDUrlHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD1F2A52218AD29100D73039 /* MIDUrlHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1F2A4F218AD29100D73039 /* MIDUrlHandler.m */; };
@@ -470,6 +471,7 @@
 		30D9ABFA1C76FD1D00F858AE /* MidtransNetworkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MidtransNetworkOperation.h; sourceTree = "<group>"; };
 		30D9ABFB1C76FD1D00F858AE /* MidtransNetworkOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MidtransNetworkOperation.m; sourceTree = "<group>"; };
 		3D8584782111C52500899462 /* MidtransCoreKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MidtransCoreKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD100F382BD635F800930FB3 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		DD1F2A4E218AD29100D73039 /* MIDUrlHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MIDUrlHandler.h; sourceTree = "<group>"; };
 		DD1F2A4F218AD29100D73039 /* MIDUrlHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MIDUrlHandler.m; sourceTree = "<group>"; };
 		DD64CE4F253DB2FF0069F4B4 /* MidtransPaymentQRIS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MidtransPaymentQRIS.h; sourceTree = "<group>"; };
@@ -928,6 +930,7 @@
 		305494311C759FF800938C17 = {
 			isa = PBXGroup;
 			children = (
+				DD100F382BD635F800930FB3 /* PrivacyInfo.xcprivacy */,
 				0C5072711F8CAE9C008F4339 /* NSString+MidtransValidation.m */,
 				E5CDEC8B1E9340CA0032DC3B /* MidtransCoreKit */,
 				3D8584872111C92400899462 /* MidtransCoreKitTests */,
@@ -1326,6 +1329,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD100F392BD635F800930FB3 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1754,7 +1758,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/MidtransCoreKit/RG",
 				);
-				MARKETING_VERSION = 1.24.1;
+				MARKETING_VERSION = 1.24.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.midtrans.MidtransCoreKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1790,7 +1794,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/MidtransCoreKit/RG",
 				);
-				MARKETING_VERSION = 1.24.1;
+				MARKETING_VERSION = 1.24.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.midtrans.MidtransCoreKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/MidtransCoreKit/MidtransCoreKit.xcodeproj/project.pbxproj
+++ b/MidtransCoreKit/MidtransCoreKit.xcodeproj/project.pbxproj
@@ -1758,7 +1758,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/MidtransCoreKit/RG",
 				);
-				MARKETING_VERSION = 1.24.2;
+				MARKETING_VERSION = 1.24.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.midtrans.MidtransCoreKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1794,7 +1794,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/MidtransCoreKit/RG",
 				);
-				MARKETING_VERSION = 1.24.2;
+				MARKETING_VERSION = 1.24.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.midtrans.MidtransCoreKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/MidtransCoreKit/PrivacyInfo.xcprivacy
+++ b/MidtransCoreKit/PrivacyInfo.xcprivacy
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeProductInteraction</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/MidtransDemo/MidtransDemo/MDOrderViewController.m
+++ b/MidtransDemo/MidtransDemo/MDOrderViewController.m
@@ -70,12 +70,12 @@
     CC_CONFIG.paymentType = [[MDOptionManager shared].ccTypeOption.value integerValue];
     switch (CC_CONFIG.paymentType) {
         case MTCreditCardPaymentTypeOneclick:
-            clientkey = FIESTAPOINT_MERCHANT_CLIENT_KEY_SANDBOX;
-            merchantServer = FIESTAPOINT_MERCHANT_SERVER_URL_SANDBOX;
+            clientkey = DEMO_STORE_MERCHANT_CLIENT_KEY_SANDBOX;
+            merchantServer = DEMO_STORE_MERCHANT_SERVER_URL_SANDBOX;
             break;
         default:
-            clientkey = FIESTAPOINT_MERCHANT_CLIENT_KEY_SANDBOX;
-            merchantServer = FIESTAPOINT_MERCHANT_SERVER_URL_SANDBOX;
+            clientkey = DEMO_STORE_MERCHANT_CLIENT_KEY_SANDBOX;
+            merchantServer = DEMO_STORE_MERCHANT_SERVER_URL_SANDBOX;
             break;
     }
     [CONFIG setClientKey:clientkey

--- a/MidtransDemo/MidtransDemo/MidtransDemoAppConfig.h
+++ b/MidtransDemo/MidtransDemo/MidtransDemoAppConfig.h
@@ -13,7 +13,7 @@
 static NSString * const ONE_CLICK_MERCHANT_SERVER_URL_SANDBOX = @"https://fauzi-one-click-sandbox.herokuapp.com/";
 static NSString * const ONE_CLICK_MERCHANT_CLIENT_KEY_SANDBOX = @"SB-Mid-client-61XuGAwQ8Bj8LxSS";
 
-static NSString * const DEMO_STORE_MERCHANT_SERVER_URL_SANDBOX = @"https://promo-engine-sample-server.herokuapp.com/";
+static NSString * const DEMO_STORE_MERCHANT_SERVER_URL_SANDBOX = @"https://demo.midtrans.com/api/";
 static NSString * const DEMO_STORE_MERCHANT_CLIENT_KEY_SANDBOX = @"VT-client-yrHf-c8Sxr-ck8tx";
 
 static NSString * const PROMO_MERCHANT_SERVER_URL_SANDBOX = @"https://charmenzy-mid-mobile-sandbox.herokuapp.com/";

--- a/MidtransKit.podspec
+++ b/MidtransKit.podspec
@@ -7,7 +7,9 @@ s.homepage         = "https://veritrans.co.id/"
 s.license          = 'MIT'
 s.author           = { "veritrans" => "dev@veritrans.co.id" }
 s.source           = { :git => 'https://github.com/veritrans/Veritrans-ios-sdk.git', :tag => s.version}
-s.platform     = :ios, '9.0'
+s.platform     = :ios, '12.0'
+s.ios.deployment_target = '12.0'
+
 s.requires_arc = true
 
 s.subspec 'UI' do |sp|
@@ -15,7 +17,7 @@ end
 
 s.source_files = 'MidtransKit/MidtransKit/**/*.{h,m}'
 s.resource_bundles = {
-    'MidtransKit' => ['MidtransKit/MidtransKit/resources/*']
+    'MidtransKit' => ['MidtransKit/MidtransKit/resources/*', 'MidtransKit/PrivacyInfo.xcprivacy']
 }
 s.dependency 'MidtransCoreKit', '1.24.1'
 s.static_framework = true

--- a/MidtransKit.podspec
+++ b/MidtransKit.podspec
@@ -7,8 +7,7 @@ s.homepage         = "https://veritrans.co.id/"
 s.license          = 'MIT'
 s.author           = { "veritrans" => "dev@veritrans.co.id" }
 s.source           = { :git => 'https://github.com/veritrans/Veritrans-ios-sdk.git', :tag => s.version}
-s.platform     = :ios, '12.0'
-s.ios.deployment_target = '12.0'
+s.platform     = :ios, '9.0'
 
 s.requires_arc = true
 

--- a/MidtransKit/MidtransKit.xcodeproj/project.pbxproj
+++ b/MidtransKit/MidtransKit.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 		3DECDFF41F9DAE610001AC9A /* see@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3DECDFE31F9DAE610001AC9A /* see@2x.png */; };
 		3DECDFF51F9DAE610001AC9A /* see@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3DECDFE41F9DAE610001AC9A /* see@3x.png */; };
 		3DECDFF61F9DAE610001AC9A /* see@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3DECDFE41F9DAE610001AC9A /* see@3x.png */; };
+		DD100F3E2BD6361500930FB3 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DD100F3A2BD6361500930FB3 /* PrivacyInfo.xcprivacy */; };
 		DD152D542637771A00B1E166 /* en_uob_ezpay_web.plist in Resources */ = {isa = PBXBuildFile; fileRef = DD152D522637771900B1E166 /* en_uob_ezpay_web.plist */; };
 		DD152D552637771A00B1E166 /* en_uob_ezpay_web.plist in Resources */ = {isa = PBXBuildFile; fileRef = DD152D522637771900B1E166 /* en_uob_ezpay_web.plist */; };
 		DD152D562637771A00B1E166 /* id_uob_ezpay_web.plist in Resources */ = {isa = PBXBuildFile; fileRef = DD152D532637771A00B1E166 /* id_uob_ezpay_web.plist */; };
@@ -1723,6 +1724,7 @@
 		3DECDFE21F9DAE610001AC9A /* see.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = see.png; path = resources/see.png; sourceTree = "<group>"; };
 		3DECDFE31F9DAE610001AC9A /* see@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "see@2x.png"; path = "resources/see@2x.png"; sourceTree = "<group>"; };
 		3DECDFE41F9DAE610001AC9A /* see@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "see@3x.png"; path = "resources/see@3x.png"; sourceTree = "<group>"; };
+		DD100F3A2BD6361500930FB3 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		DD152D522637771900B1E166 /* en_uob_ezpay_web.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = en_uob_ezpay_web.plist; path = MidtransKit/resources/en_uob_ezpay_web.plist; sourceTree = SOURCE_ROOT; };
 		DD152D532637771A00B1E166 /* id_uob_ezpay_web.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = id_uob_ezpay_web.plist; path = MidtransKit/resources/id_uob_ezpay_web.plist; sourceTree = SOURCE_ROOT; };
 		DD2A919A22CC85A70081562A /* alfamidi@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "alfamidi@2x.png"; path = "resources/alfamidi@2x.png"; sourceTree = "<group>"; };
@@ -2445,6 +2447,7 @@
 		305494121C759EDF00938C17 = {
 			isa = PBXGroup;
 			children = (
+				DD100F3A2BD6361500930FB3 /* PrivacyInfo.xcprivacy */,
 				E58FCE981E94D06900632085 /* MidtransCoreKit.xcodeproj */,
 				E5CDEC981E9340E80032DC3B /* MidtransKit */,
 				E57123F51E9380E80064F515 /* MidtransKitResources */,
@@ -4207,6 +4210,7 @@
 				0CE1D27B1F62A752003A012F /* bni_va@4x.png in Resources */,
 				DD64CE69253EA6560069F4B4 /* qrisshopeepay@2x.png in Resources */,
 				0CC900351F70244A0058E93C /* en_bri_epay.plist in Resources */,
+				DD100F3E2BD6361500930FB3 /* PrivacyInfo.xcprivacy in Resources */,
 				3DECDFE91F9DAE610001AC9A /* download@3x.png in Resources */,
 				0C9634F51FE11A1F00EF89DF /* gojek_icon@2x.png in Resources */,
 				DDA4860127630B1000D9A0AC /* brimo@1x.png in Resources */,
@@ -5149,7 +5153,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.24.1;
+				MARKETING_VERSION = 1.24.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.midtrans.MidtransKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5180,7 +5184,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.24.1;
+				MARKETING_VERSION = 1.24.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.midtrans.MidtransKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MidtransKit/MidtransKit.xcodeproj/project.pbxproj
+++ b/MidtransKit/MidtransKit.xcodeproj/project.pbxproj
@@ -5153,7 +5153,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.24.2;
+				MARKETING_VERSION = 1.24.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.midtrans.MidtransKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5184,7 +5184,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.24.2;
+				MARKETING_VERSION = 1.24.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.midtrans.MidtransKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MidtransKit/PrivacyInfo.xcprivacy
+++ b/MidtransKit/PrivacyInfo.xcprivacy
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeProductInteraction</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePaymentInfo</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
1. set ios deployment target to ios 12
2. add privacy manifest for all integration (manual, spm, cocoapods)



MidtransCoreKit:
1. SPM:
<img width="1329" alt="Screenshot 2024-04-22 at 14 28 18" src="https://github.com/veritrans/Veritrans-ios-sdk/assets/3756851/3200cab1-7825-4a9d-b83e-3af08aee614a">

2. Cocoapods:
<img width="1329" alt="Screenshot 2024-04-22 at 14 30 19" src="https://github.com/veritrans/Veritrans-ios-sdk/assets/3756851/f1cea2f8-90e9-4ea6-aa57-0868fd4de655">


3. Manual:

![Screenshot 2024-04-23 at 07 31 55](https://github.com/veritrans/Veritrans-ios-sdk/assets/3756851/397898cb-32eb-4d11-a2dc-87df16469c83)

MidtransKit:
1. SPM:
<img width="1330" alt="Screenshot 2024-04-22 at 14 25 45" src="https://github.com/veritrans/Veritrans-ios-sdk/assets/3756851/8b9831d9-91d9-4da0-aa3e-a6b64e8fa93d">

2. Cocoapods:
<img width="1331" alt="Screenshot 2024-04-22 at 14 35 48" src="https://github.com/veritrans/Veritrans-ios-sdk/assets/3756851/1cae6355-2f79-476c-be58-5d106bd4dcd7">

3. Manual
<img width="1330" alt="Screenshot 2024-04-22 at 14 43 45" src="https://github.com/veritrans/Veritrans-ios-sdk/assets/3756851/8c08e61a-0b5f-445c-b879-e43e4efb32b4">
