### PR TITLE
Implement Promo Endpoint

### DIFF
--- a/MidtransCoreKit/MidtransCoreKit/MidtransConstant.h
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransConstant.h
@@ -99,6 +99,7 @@ static NSString * const ENDPOINT_CHARGE = @"%@/transactions/%@/pay";
 static NSString * const ENDPOINT_CHECK_STATUS_RBA = @"%@/transactions/%@/status";
 static NSString * const ENDPOINT_TRANSACTION_DETAIL = @"%@/transactions/%@";
 static NSString * const ENDPOINT_PAYMENT_PAGES = @"%@/payment_pages/%@";
+static NSString * const ENDPOINT_PROMO = @"%@/promos/%@/search";
 
 static NSString * const NOTIFICATION_GOPAY_STATUS = @"NOTIFICATION_GOPAY_STATUS";
 /**
@@ -215,6 +216,7 @@ static NSString *const MIDTRANS_GOPAY_PREFIX_NEW = @"https://gojek.link/";
 
 static NSString *const MIDTRANS_EXBIN_DATA = @"exbin_data";
 static NSInteger const MIDTRANS_SUPPORTED_BIN_LENGTH =  8;
+static NSString *const FEATURE_TYPES_PROMO = @"PROMO";
 
 /**
  *  if needed we maybe need it as is to detect ios version and also device version

--- a/MidtransCoreKit/MidtransCoreKit/MidtransMerchantClient.h
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransMerchantClient.h
@@ -14,6 +14,7 @@
 #import "MidtransTransactionExpire.h"
 #import "MidtransTransactionResult.h"
 #import "MidtransPaymentRequestV2SavedTokens.h"
+#import "MidtransPromoResponse.h"
 
 @class MidtransTransactionTokenResponse,MidtransPaymentRequestV2Response,SNPPointResponse;
 /**
@@ -88,5 +89,8 @@
 - (void)deleteMaskedCreditCard:(MidtransMaskedCreditCard *_Nonnull)maskedCard
                          token:(MidtransTransactionTokenResponse *_Nonnull)token
                     completion:(void(^_Nullable)(BOOL success))completion;
+
+- (void)getPromoWithToken:(NSString * _Nonnull )token
+               completion:(void (^_Nullable)(MidtransPromoPromoDetails *_Nullable promoResponse, NSError *_Nullable error))completion;
 
 @end

--- a/MidtransCoreKit/MidtransCoreKit/MidtransMerchantClient.m
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransMerchantClient.m
@@ -478,6 +478,24 @@ NSString *const FETCH_MASKEDCARD_URL = @"%@/users/%@/tokens";
     }];
 }
 
+- (void)getPromoWithToken:(NSString * _Nonnull )token
+               completion:(void (^_Nullable)(MidtransPromoPromoDetails *_Nullable promoResponse, NSError *_Nullable error))completion {
+    NSString *URL = [NSString stringWithFormat:ENDPOINT_PROMO, [PRIVATECONFIG snapURL], token];
+    [[MidtransNetworking shared] postToURL:URL parameters:nil callback:^(id response, NSError *error) {
+        if (response) {
+            MidtransPromoPromoDetails *promoResponse = [[MidtransPromoPromoDetails alloc] initWithDictionary:response];
+            if (completion) {
+                completion(promoResponse, error);
+            }
+        }
+        else {
+            if (completion) {
+                completion(nil, error);
+            }
+        }
+    }];
+}
+
 - (NSString *)getErrorMessageFromErrorResponse:(id)errorResponse {
     NSString *errorMessage;
     if ([errorResponse isKindOfClass:[NSArray class]]) {

--- a/MidtransCoreKit/MidtransCoreKit/MidtransPaymentRequestV2Response.h
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransPaymentRequestV2Response.h
@@ -22,6 +22,7 @@
 @property (nonatomic, strong) MidtransPaymentRequestV2Callbacks *callbacks;
 @property (nonatomic, strong) MidtransTransactionExpire *expire;
 @property (nonatomic, strong) NSDictionary *custom;
+@property (nonatomic, strong) NSArray *featureTypes;
 
 + (instancetype)modelObjectWithDictionary:(NSDictionary *)dict;
 - (instancetype)initWithDictionary:(NSDictionary *)dict;

--- a/MidtransCoreKit/MidtransCoreKit/MidtransPaymentRequestV2Response.m
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransPaymentRequestV2Response.m
@@ -27,6 +27,7 @@ NSString *const kMidtransPaymentRequestV2ResponseCallbacks = @"callbacks";
 NSString *const kMIdtransPaymentRequestV2ResponseExpire  = @"expiry";
 NSString *const KMidtransPaymentRequestV2ResponseCustomField =@"custom";
 NSString *const kMidtransCheckoutResponsePromo = @"promo_details";
+NSString *const kMidtransCheckoutResponseFeatureTypes = @"feature_types";
 
 @interface MidtransPaymentRequestV2Response ()
 
@@ -45,6 +46,7 @@ NSString *const kMidtransCheckoutResponsePromo = @"promo_details";
 @synthesize token = _token;
 @synthesize promos = _promos;
 @synthesize callbacks = _callbacks;
+@synthesize featureTypes = _featureTypes;
 
 
 + (instancetype)modelObjectWithDictionary:(NSDictionary *)dict
@@ -94,6 +96,7 @@ NSString *const kMidtransCheckoutResponsePromo = @"promo_details";
         self.expire = [MidtransTransactionExpire modelObjectWithDictionary:[dict objectForKey:kMIdtransPaymentRequestV2ResponseExpire]];
         self.custom  = [self objectOrNilForKey:KMidtransPaymentRequestV2ResponseCustomField fromDictionary:dict];
         self.promos = [MidtransPromoPromoDetails modelObjectWithDictionary:[dict objectForKey:kMidtransCheckoutResponsePromo]];
+        self.featureTypes = [self objectOrNilForKey:kMidtransCheckoutResponseFeatureTypes fromDictionary:dict];
     }
     
     
@@ -136,6 +139,15 @@ NSString *const kMidtransCheckoutResponsePromo = @"promo_details";
     
    
     [mutableDict setValue:self.promos forKey:kMidtransCheckoutResponsePromo];
+    NSMutableArray *tempArrayForFeatureTypes = [NSMutableArray array];
+    for (NSObject *subArrayObject in self.featureTypes) {
+        if ([subArrayObject respondsToSelector:@selector(dictionaryRepresentation)]) {
+            [tempArrayForFeatureTypes addObject:[subArrayObject performSelector:@selector(dictionaryRepresentation)]];
+        } else {
+            [tempArrayForFeatureTypes addObject:subArrayObject];
+        }
+    }
+    [mutableDict setValue:[NSArray arrayWithArray:tempArrayForFeatureTypes] forKey:kMidtransCheckoutResponseFeatureTypes];
     
     return [NSDictionary dictionaryWithDictionary:mutableDict];
 }
@@ -168,6 +180,7 @@ NSString *const kMidtransCheckoutResponsePromo = @"promo_details";
     self.callbacks = [aDecoder decodeObjectForKey:kMidtransPaymentRequestV2ResponseCallbacks];
     self.expire = [aDecoder decodeObjectForKey:kMIdtransPaymentRequestV2ResponseExpire];
     self.custom = [aDecoder decodeObjectForKey:KMidtransPaymentRequestV2ResponseCustomField];
+    self.featureTypes = [aDecoder decodeObjectForKey:kMidtransCheckoutResponseFeatureTypes];
     return self;
 }
 
@@ -182,6 +195,7 @@ NSString *const kMidtransCheckoutResponsePromo = @"promo_details";
     [aCoder encodeObject:_itemDetails forKey:kMidtransPaymentRequestV2ResponseItemDetails];
     [aCoder encodeObject:_token forKey:kMidtransPaymentRequestV2ResponseToken];
     [aCoder encodeObject:_callbacks forKey:kMidtransPaymentRequestV2ResponseCallbacks];
+    [aCoder encodeObject:_featureTypes forKey:kMidtransCheckoutResponseFeatureTypes];
 }
 
 - (id)copyWithZone:(NSZone *)zone
@@ -198,6 +212,7 @@ NSString *const kMidtransCheckoutResponsePromo = @"promo_details";
         copy.itemDetails = [self.itemDetails copyWithZone:zone];
         copy.token = [self.token copyWithZone:zone];
         copy.callbacks = [self.callbacks copyWithZone:zone];
+        copy.featureTypes = [self.featureTypes copyWithZone:zone];
     }
     
     return copy;

--- a/MidtransCoreKit/MidtransCoreKit/Promo/MidtransPromoPromoDetails.h
+++ b/MidtransCoreKit/MidtransCoreKit/Promo/MidtransPromoPromoDetails.h
@@ -6,12 +6,14 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "MidtransPromoPromos.h"
 
 
 
 @interface MidtransPromoPromoDetails : NSObject <NSCoding, NSCopying>
 
-@property (nonatomic, strong) NSArray *promos;
+@property (nonatomic, strong) NSArray <MidtransPromoPromos *>*promos;
+;
 
 + (instancetype)modelObjectWithDictionary:(NSDictionary *)dict;
 - (instancetype)initWithDictionary:(NSDictionary *)dict;

--- a/MidtransKit/MidtransKit/classes/MidtransNewCreditCardViewController.m
+++ b/MidtransKit/MidtransKit/classes/MidtransNewCreditCardViewController.m
@@ -213,8 +213,7 @@ MidtransCommonTSCViewControllerDelegate
     self.installment = [[MidtransPaymentRequestV2Installment alloc]
                         initWithDictionary: [[self.creditCardInfo dictionaryRepresentation] valueForKey:@"installment"]];
     
-    if (self.responsePayment.promos) {
-        self.promos = self.responsePayment.promos;
+    if (self.promos) {
         if (self.promos.promos.count) {
             self.promoAvailable = YES;
             [self updatePromoViewWithCreditCardNumber:nil];

--- a/MidtransKit/MidtransKit/classes/MidtransUIListCell.h
+++ b/MidtransKit/MidtransKit/classes/MidtransUIListCell.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
-@class MidtransPaymentListModel,MidtransPaymentRequestV2Response;
+
+@class MidtransPaymentListModel,MidtransPaymentRequestV2Response, MidtransPromoPromoDetails;
 @interface MidtransUIListCell : UITableViewCell
 @property (nonatomic) NSDictionary *item;
 @property (weak, nonatomic) IBOutlet UIView *unavailableVIew;
@@ -18,7 +19,7 @@
 @property (weak, nonatomic) IBOutlet UILabel *tscTextStatusLabel;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *textStatusHeightConstraint;
 @property (weak, nonatomic) IBOutlet UILabel *promoNotificationView;
-- (void)configurePaymetnList:(MidtransPaymentListModel *)paymentList withFullPaymentResponse:(MidtransPaymentRequestV2Response *)response;
+- (void)configurePaymentList:(MidtransPaymentListModel *)paymentList withFullPaymentResponse:(MidtransPaymentRequestV2Response *)response promos:(MidtransPromoPromoDetails *)promos;
 -(void) configureUobOptionList:(NSString *)uobOptionTitle withUobOptionDescription:(NSString*)uobOptionDescription
                    optionImage:(NSString *)menuImage;
 @end

--- a/MidtransKit/MidtransKit/classes/MidtransUIListCell.m
+++ b/MidtransKit/MidtransKit/classes/MidtransUIListCell.m
@@ -16,7 +16,7 @@
     self.promoNotificationView.layer.cornerRadius = 5.0f;
     self.promoNotificationView.layer.masksToBounds = YES;
 }
-- (void)configurePaymetnList:(MidtransPaymentListModel *)paymentList withFullPaymentResponse:(MidtransPaymentRequestV2Response *)response {
+- (void)configurePaymentList:(MidtransPaymentListModel *)paymentList withFullPaymentResponse:(MidtransPaymentRequestV2Response *)response promos:(MidtransPromoPromoDetails *)promos {
     self.promoNotificationView.hidden =  YES;
     self.paymentMethodNameLabel.text = paymentList.title;
     self.paymentMethodDescriptionLabel.text = paymentList.internalBaseClassDescription;
@@ -28,7 +28,7 @@
         imagePath = @"brimo";
     }
     if ([paymentList.internalBaseClassIdentifier isEqualToString:@"credit_card"]) {
-        if (response.promos.promos.count) {
+        if (promos.promos.count) {
             self.promoNotificationView.hidden =  NO;
         }
     }

--- a/MidtransKit/MidtransKit/classes/VTPaymentListView.h
+++ b/MidtransKit/MidtransKit/classes/VTPaymentListView.h
@@ -25,6 +25,6 @@
 @property (nonatomic) MidtransPaymentMethodHeader *headerView;
 
 @property (weak, nonatomic) IBOutlet UIImageView *secureBadgeImage;
-- (void)setPaymentMethods:(NSArray *)paymentMethods andItems:(NSArray *)items withResponse:(MidtransPaymentRequestV2Response *)response;
+- (void)setPaymentMethods:(NSArray *)paymentMethods andItems:(NSArray *)items withResponse:(MidtransPaymentRequestV2Response *)response promos:(MidtransPromoPromoDetails *)promos;
 
 @end

--- a/MidtransKit/MidtransKit/classes/VTPaymentListView.m
+++ b/MidtransKit/MidtransKit/classes/VTPaymentListView.m
@@ -17,6 +17,7 @@
 @property (nonatomic) NSArray *paymentMethods;
 @property (nonatomic) BOOL shouldExpand;
 @property (nonatomic,strong) MidtransPaymentRequestV2Response *responsePayment;
+@property (nonatomic,strong) MidtransPromoPromoDetails *promos;
 @property (nonatomic) NSArray *items;
 @end
 
@@ -47,10 +48,11 @@
     CGContextStrokePath(currentContext);
 }
 
-- (void)setPaymentMethods:(NSArray *)paymentMethods andItems:(NSArray *)items withResponse:(MidtransPaymentRequestV2Response *)response {
+- (void)setPaymentMethods:(NSArray *)paymentMethods andItems:(NSArray *)items withResponse:(MidtransPaymentRequestV2Response *)response promos:(MidtransPromoPromoDetails *)promos {
     
     self.responsePayment = response;
     self.items = items;
+    self.promos = promos;
     
     self.headerView.priceAmountLabel.text = response.transactionDetails.grossAmount.formattedCurrencyNumber;
     
@@ -73,7 +75,7 @@
     if (!cell) {
         cell = [[MidtransUIListCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"MidtransUIListCell"];
     }
-    [cell configurePaymetnList:self.paymentMethods[indexPath.row] withFullPaymentResponse:self.responsePayment];
+    [cell configurePaymentList:self.paymentMethods[indexPath.row] withFullPaymentResponse:self.responsePayment promos:self.promos];
     return cell;
 }
 

--- a/MidtransKit/MidtransKit/classes/VTVAListController.h
+++ b/MidtransKit/MidtransKit/classes/VTVAListController.h
@@ -11,4 +11,5 @@
 @class MidtransPaymentRequestV2Response;
 @interface VTVAListController : MidtransUIPaymentController
 @property (nonatomic,strong) MidtransPaymentRequestV2Response *paymentResponse;
+@property (nonatomic) MidtransPromoPromoDetails *promos;
 @end

--- a/MidtransKit/MidtransKit/classes/VTVAListController.m
+++ b/MidtransKit/MidtransKit/classes/VTVAListController.m
@@ -88,7 +88,7 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     MidtransUIListCell *cell = [tableView dequeueReusableCellWithIdentifier:@"MidtransUIListCell"];
-    [cell configurePaymetnList:self.vaList[indexPath.row] withFullPaymentResponse:self.paymentResponse];
+    [cell configurePaymentList:self.vaList[indexPath.row] withFullPaymentResponse:self.paymentResponse promos:self.promos];
     return cell;
 }
 


### PR DESCRIPTION
1. update promo implementation using promo endpoint


Petting response from promo endpoint as shown on the log:

![Screenshot 2024-06-13 at 09 36 26](https://github.com/veritrans/Veritrans-ios-sdk/assets/3756851/9e88dbe2-6099-4dc0-86e0-ef9e99c9ccb1)

Promo implemented on the credit card UI.
![Screenshot 2024-06-13 at 09 35 18](https://github.com/veritrans/Veritrans-ios-sdk/assets/3756851/bf1507e7-1336-4f13-b23b-abe440753dad)
