### PR TITLE
CHEC-2237 deprecated openurl

### DIFF
--- a/MidtransCoreKit/MidtransCoreKit/MidtransConstant.h
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransConstant.h
@@ -15,7 +15,6 @@ static NSString * const MIDTRANS_CUSTOMFIELD_1 = @"custom_field1";
 static NSString * const MIDTRANS_CUSTOMFIELD_2 = @"custom_field2";
 static NSString * const MIDTRANS_CUSTOMFIELD_3 = @"custom_field3";
 static NSString * const GOJEK_APPSTORE_URL = @"https://apps.apple.com/id/app/gojek/id944875099";
-static NSString * const SHOPEE_APPSTORE_URL = @"https://apps.apple.com/id/app/shopee-indonesia/id959841443";
 static NSString * const MIDTRANS_ERROR_DOMAIN = @"error.midtrans.com";
 
 /**

--- a/MidtransCoreKit/MidtransCoreKit/MidtransConstant.h
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransConstant.h
@@ -14,7 +14,8 @@ static NSString * const MIDTRANS_SDK_CURRENT_VERSION = @"1.27.1";
 static NSString * const MIDTRANS_CUSTOMFIELD_1 = @"custom_field1";
 static NSString * const MIDTRANS_CUSTOMFIELD_2 = @"custom_field2";
 static NSString * const MIDTRANS_CUSTOMFIELD_3 = @"custom_field3";
-static NSString * const GOJEK_APP_ITUNES_LINK = @"itms://itunes.apple.com/us/app/apple-store/id944875099?mt=8";
+static NSString * const GOJEK_APPSTORE_URL = @"https://apps.apple.com/id/app/gojek/id944875099";
+static NSString * const SHOPEE_APPSTORE_URL = @"https://apps.apple.com/id/app/shopee-indonesia/id959841443";
 static NSString * const MIDTRANS_ERROR_DOMAIN = @"error.midtrans.com";
 
 /**

--- a/MidtransCoreKit/MidtransCoreKit/MidtransPaymentWebController.m
+++ b/MidtransCoreKit/MidtransCoreKit/MidtransPaymentWebController.m
@@ -123,7 +123,9 @@
         ![webView.URL.scheme isEqual:@"https"] &&
         ![webView.URL.scheme isEqual:@"about:blank"]) {
         if ([[UIApplication sharedApplication]canOpenURL:webView.URL]) {
-            [[UIApplication sharedApplication]openURL:webView.URL];
+            [[UIApplication sharedApplication] openURL:webView.URL
+                                               options:@{}
+                                     completionHandler:nil];
         }
     }
     NSString *requestURL = [navigationAction.request.URL absoluteString];

--- a/MidtransKit/MidtransKit/MidShopeePayViewController.m
+++ b/MidtransKit/MidtransKit/MidShopeePayViewController.m
@@ -17,7 +17,7 @@
 #import "VTGuideCell.h"
 #import "MidtransUIConfiguration.h"
 #import "MidtransTransactionDetailViewController.h"
-#define IPAD UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+#define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
 
 @interface MidShopeePayViewController ()<UITableViewDelegate,UITableViewDataSource>
 @property (strong, nonatomic) IBOutlet MIDGopayView *view;
@@ -78,7 +78,7 @@
     
     [self.view.tableView reloadData];
     
-    if (IPAD) {
+    if (IS_IPAD) {
         self.view.topWrapperView.hidden = YES;
         self.view.gopayTopViewHeightConstraints.constant = 0.0f;
     } else {
@@ -94,7 +94,7 @@
     self.view.finishPaymentButton.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
     self.view.finishPaymentButton.imageView.tintColor = [UIColor whiteColor];
     
-    if (IPAD) {
+    if (IS_IPAD) {
         NSString *filenameByLanguage = [[MidtransDeviceHelper deviceCurrentLanguage] stringByAppendingFormat:@"_ipad_%@", MIDTRANS_PAYMENT_SHOPEEPAY];
         NSString *guidePath = [VTBundle pathForResource:filenameByLanguage ofType:@"plist"];
         if (guidePath == nil) {
@@ -142,7 +142,7 @@
     if(indexPath.row %2 ==0) {
         cell.backgroundColor = [UIColor colorWithRed:0.95 green:0.95 blue:0.95 alpha:1.0];
     }
-    if (IPAD && indexPath.row == 1) {
+    if (IS_IPAD && indexPath.row == 1) {
         cell.imageBottomInstruction.hidden = NO;
         [cell.imageBottomInstruction setImage:[UIImage imageNamed:@"gopay_scan_2" inBundle:VTBundle compatibleWithTraitCollection:nil]];
         cell.bottomImageInstructionsConstraints.constant = 120.0f;
@@ -167,13 +167,18 @@
         
 }
 - (IBAction)installShopeeAppButtonDidTapped:(id)sender {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:GOJEK_APP_ITUNES_LINK]];
+    NSURL *appURL = [NSURL URLWithString:SHOPEE_APPSTORE_URL];
+    [[UIApplication sharedApplication] openURL:appURL
+                                       options:@{}
+                             completionHandler:nil];
 }
 - (void)openShopeeAppWithResult:(MidtransTransactionResult *)result {
     NSString *gojekDeeplinkString = [result.additionalData objectForKey:@"deeplink_url"];
     NSURL *deeplinkURL = [NSURL URLWithString:gojekDeeplinkString];
     if ([[UIApplication sharedApplication] canOpenURL:deeplinkURL]) {
-        [[UIApplication sharedApplication] openURL:deeplinkURL];
+        [[UIApplication sharedApplication] openURL:deeplinkURL
+                                           options:@{}
+                                 completionHandler:nil];
     }
 }
 
@@ -185,7 +190,7 @@
     
     [self showLoadingWithText:[VTClassHelper getTranslationFromAppBundleForString:@"Processing your transaction"]];
     id<MidtransPaymentDetails>paymentDetails;
-    if (IPAD) {
+    if (IS_IPAD) {
         paymentDetails = [[MidtransPaymentQRIS alloc]initWithAcquirer:MIDTRANS_PAYMENT_SHOPEEPAY];
     } else {
          paymentDetails = [[MidtransPaymentShopeePay alloc] init];
@@ -199,7 +204,7 @@
             [self showToastInviewWithMessage:error.description];
         }
         else {
-            if (IPAD) {
+            if (IS_IPAD) {
                 MidQRISDetailViewController *qrisDetailVC = [[MidQRISDetailViewController  alloc] initWithToken:self.token paymentMethodName:self.paymentMethod];
                 qrisDetailVC.result = result;
                 [self.navigationController pushViewController:qrisDetailVC animated:YES];

--- a/MidtransKit/MidtransKit/UOB/MidUobViewController.m
+++ b/MidtransKit/MidtransKit/UOB/MidUobViewController.m
@@ -104,7 +104,9 @@
     }
     NSURL *uobWebURL = [NSURL URLWithString:uobWebStringURL];
     if ([[UIApplication sharedApplication] canOpenURL:uobWebURL]) {
-        [[UIApplication sharedApplication] openURL:uobWebURL];
+        [[UIApplication sharedApplication] openURL:uobWebURL
+                                           options:@{}
+                                 completionHandler:nil];
     }
 }
 

--- a/MidtransKit/MidtransKit/classes/MidGopayDetailViewController.m
+++ b/MidtransKit/MidtransKit/classes/MidGopayDetailViewController.m
@@ -5,7 +5,7 @@
 //  Created by Vanbungkring on 11/28/17.
 //  Copyright © 2017 Midtrans. All rights reserved.
 //
-#define IPAD UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+#define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
 #import <MidtransCoreKit/MidtransCoreKit.h>
 #import "MidGopayDetailViewController.h"
 #import "MIDGopayDetailView.h"
@@ -51,7 +51,7 @@
     [self.view.guideTableView registerNib:[UINib nibWithNibName:@"MidtransDirectHeader" bundle:VTBundle] forCellReuseIdentifier:@"MidtransDirectHeader"];
     [self.view.guideTableView registerNib:[UINib nibWithNibName:@"VTGuideCell" bundle:VTBundle] forCellReuseIdentifier:@"VTGuideCell"];
     
-    if (IPAD) {
+    if (IS_IPAD) {
         
         //Get current year
         self.view.expireTimesLabel.text = [VTClassHelper getTranslationFromAppBundleForString:@"Please complete your payment in"];
@@ -128,7 +128,7 @@
     NSString *content;
     title = [VTClassHelper getTranslationFromAppBundleForString:@"Finish Payment"];
     content = [VTClassHelper getTranslationFromAppBundleForString:@"Make sure payment has been completed within the Gojek app."];
-    if (IPAD) {
+    if (IS_IPAD) {
         content = [VTClassHelper getTranslationFromAppBundleForString:@"Make sure the QR code successfully scanned and payment has been completed within the Gojek app."];
     }
     UIAlertController *alertController = [UIAlertController
@@ -178,7 +178,7 @@
     [self processCheckOut];
 }
 - (void)processCheckOut {
-    if (IPAD) {
+    if (IS_IPAD) {
         [self.navigationController dismissViewControllerAnimated:YES completion:^{
             NSDictionary *userInfo = @{TRANSACTION_RESULT_KEY:self.result};
             [[NSNotificationCenter defaultCenter] postNotificationName:TRANSACTION_PENDING object:nil userInfo:userInfo];
@@ -186,7 +186,9 @@
     } else {
         NSURL *gojekConstructURL = [NSURL URLWithString:[self.result.additionalData objectForKey:@"deeplink_url"]];
         if ([[UIApplication sharedApplication] canOpenURL:gojekConstructURL]) {
-            [[UIApplication sharedApplication] openURL:gojekConstructURL];
+            [[UIApplication sharedApplication] openURL:gojekConstructURL
+                                               options:@{}
+                                     completionHandler:nil];
         }
         [self.navigationController dismissViewControllerAnimated:YES completion:^{
             NSDictionary *userInfo = @{TRANSACTION_RESULT_KEY:self.result};
@@ -237,13 +239,13 @@
     if(indexPath.row %2 ==0) {
         cell.backgroundColor = [UIColor colorWithRed:0.95 green:0.95 blue:0.95 alpha:1.0];
     }
-    if (IPAD && indexPath.row == 1) {
+    if (IS_IPAD && indexPath.row == 1) {
         cell.imageBottomInstruction.hidden = NO;
         [cell.imageBottomInstruction setImage:[UIImage imageNamed:@"gopay_scan_1" inBundle:VTBundle compatibleWithTraitCollection:nil]];
         cell.bottomImageInstructionsConstraints.constant = 120.0f;
         cell.bottomNotes.hidden = NO;
     }
-    if (IPAD && indexPath.row == 2) {
+    if (IS_IPAD && indexPath.row == 2) {
         cell.imageBottomInstruction.hidden = NO;
         cell.bottomNotes.hidden = YES;
         [cell.imageBottomInstruction setImage:[UIImage imageNamed:@"gopay_scan_2" inBundle:VTBundle compatibleWithTraitCollection:nil]];
@@ -254,10 +256,10 @@
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (IPAD && indexPath.row == 1) {
+    if (IS_IPAD && indexPath.row == 1) {
         return 200;
     }
-    if (IPAD && indexPath.row == 2) {
+    if (IS_IPAD && indexPath.row == 2) {
         return 200;
     }
     else {

--- a/MidtransKit/MidtransKit/classes/MidGopayViewController.m
+++ b/MidtransKit/MidtransKit/classes/MidGopayViewController.m
@@ -178,13 +178,19 @@
         }
 }
 - (IBAction)installGOJEKappButtonDidTapped:(id)sender {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:GOJEK_APP_ITUNES_LINK]];
+    NSURL *appURL = [NSURL URLWithString:GOJEK_APPSTORE_URL];
+    [[UIApplication sharedApplication] openURL:appURL
+                                       options:@{}
+                             completionHandler:nil];
 }
 - (void)openGojekAppWithResult:(MidtransTransactionResult *)result {
     NSString *gojekDeeplinkString = [result.additionalData objectForKey:@"deeplink_url"];
     NSURL *deeplinkURL = [NSURL URLWithString:gojekDeeplinkString];
+    
     if ([[UIApplication sharedApplication] canOpenURL:deeplinkURL]) {
-        [[UIApplication sharedApplication] openURL:deeplinkURL];
+        [[UIApplication sharedApplication] openURL:deeplinkURL
+                                           options:@{}
+                                 completionHandler:nil];
     }
 }
 

--- a/MidtransKit/MidtransKit/classes/MidGopayViewController.m
+++ b/MidtransKit/MidtransKit/classes/MidGopayViewController.m
@@ -17,7 +17,7 @@
 #import "VTGuideCell.h"
 #import "MidtransUIConfiguration.h"
 #import "MidtransTransactionDetailViewController.h"
-#define IPAD UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+#define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
 
 @interface MidGopayViewController ()<UITableViewDelegate,UITableViewDataSource>
 @property (strong, nonatomic) IBOutlet MIDGopayView *view;
@@ -75,7 +75,7 @@
     
     [self.view.tableView reloadData];
     
-    if (IPAD) {
+    if (IS_IPAD) {
         self.view.topWrapperView.hidden = YES;
         self.view.gopayTopViewHeightConstraints.constant = 0.0f;
         self.view.topNoticeLabel.text = [VTClassHelper getTranslationFromAppBundleForString:@"Please complete your ‘GoPay‘ payment via ‘Gojek‘ app"];
@@ -106,7 +106,7 @@
     self.view.finishPaymentButton.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
     self.view.finishPaymentButton.imageView.tintColor = [UIColor whiteColor];
     
-    if (IPAD) {
+    if (IS_IPAD) {
         NSString *filenameByLanguage = [[MidtransDeviceHelper deviceCurrentLanguage] stringByAppendingFormat:@"_ipad_%@", MIDTRANS_PAYMENT_GOPAY];
         NSString *guidePath = [VTBundle pathForResource:filenameByLanguage ofType:@"plist"];
         if (guidePath == nil) {
@@ -154,7 +154,7 @@
     if(indexPath.row %2 ==0) {
         cell.backgroundColor = [UIColor colorWithRed:0.95 green:0.95 blue:0.95 alpha:1.0];
     }
-    if (IPAD && indexPath.row == 1) {
+    if (IS_IPAD && indexPath.row == 1) {
         cell.imageBottomInstruction.hidden = NO;
         [cell.imageBottomInstruction setImage:[UIImage imageNamed:@"gopay_scan_2" inBundle:VTBundle compatibleWithTraitCollection:nil]];
         cell.bottomImageInstructionsConstraints.constant = 120.0f;
@@ -202,7 +202,7 @@
     
     [self showLoadingWithText:[VTClassHelper getTranslationFromAppBundleForString:@"Processing your transaction"]];
     id<MidtransPaymentDetails>paymentDetails;
-    if (IPAD) {
+    if (IS_IPAD) {
         paymentDetails = [[MidtransPaymentQRIS alloc]initWithAcquirer:MIDTRANS_PAYMENT_GOPAY];
     } else {
          paymentDetails = [[MidtransPaymentGOPAY alloc] init];
@@ -216,7 +216,7 @@
             [self showToastInviewWithMessage:error.description];
         }
         else {
-            if (IPAD) {
+            if (IS_IPAD) {
                 MidQRISDetailViewController *gopayDetailVC = [[MidQRISDetailViewController  alloc] initWithToken:self.token paymentMethodName:self.paymentMethod];
                 gopayDetailVC.result = result;
                 [self.navigationController pushViewController:gopayDetailVC animated:YES];

--- a/MidtransKit/MidtransKit/classes/MidQRISDetailViewController.m
+++ b/MidtransKit/MidtransKit/classes/MidQRISDetailViewController.m
@@ -5,7 +5,7 @@
 //  Created by Vanbungkring on 11/28/17.
 //  Copyright © 2017 Midtrans. All rights reserved.
 //
-#define IPAD UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+#define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
 #import <MidtransCoreKit/MidtransCoreKit.h>
 #import "MidQRISDetailViewController.h"
 #import "MIDGopayDetailView.h"
@@ -206,7 +206,7 @@
     if(indexPath.row %2 ==0) {
         cell.backgroundColor = [UIColor colorWithRed:0.95 green:0.95 blue:0.95 alpha:1.0];
     }
-    if (IPAD && indexPath.row == 1) {
+    if (IS_IPAD && indexPath.row == 1) {
         cell.imageBottomInstruction.hidden = NO;
         cell.bottomNotes.hidden = YES;
         [cell.imageBottomInstruction setImage:[UIImage imageNamed:@"gopay_scan_2" inBundle:VTBundle compatibleWithTraitCollection:nil]];

--- a/MidtransKit/MidtransKit/classes/VTPaymentListController.m
+++ b/MidtransKit/MidtransKit/classes/VTPaymentListController.m
@@ -5,7 +5,7 @@
 //  Created by Nanang Rafsanjani on 2/22/16.
 //  Copyright © 2016 Veritrans. All rights reserved.
 //
-#define IPAD UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+#define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
 #import "VTPaymentListController.h"
 #import "VTClassHelper.h"
 #import "MidtransUIListCell.h"
@@ -298,10 +298,22 @@
 }
 
 - (void)redirectToGopayOrShopeePay:(MidtransPaymentListModel *)paymentMethod {
-    MidGopayViewController *midGopayVC = [[MidGopayViewController alloc] initWithToken:self.token
-                                                                     paymentMethodName:paymentMethod
-                                                                  directPaymentFeature:self.singlePayment];
-    [self.navigationController pushViewController:midGopayVC animated:!self.singlePayment];
+    NSString *identifier = [paymentMethod.internalBaseClassIdentifier stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    
+    if ([identifier caseInsensitiveCompare:MIDTRANS_PAYMENT_GOPAY] == NSOrderedSame ||
+        [identifier caseInsensitiveCompare:MIDTRANS_PAYMENT_QRIS_GOPAY] == NSOrderedSame) {
+        
+        MidGopayViewController *midGopayVC = [[MidGopayViewController alloc] initWithToken:self.token
+                                                                         paymentMethodName:paymentMethod
+                                                                      directPaymentFeature:self.singlePayment];
+        [self.navigationController pushViewController:midGopayVC animated:!self.singlePayment];
+        
+    } else {
+        MidShopeePayViewController *midShopeepayVC = [[MidShopeePayViewController alloc] initWithToken:self.token
+                                                                                     paymentMethodName:paymentMethod
+                                                                                  directPaymentFeature:self.singlePayment];
+        [self.navigationController pushViewController:midShopeepayVC animated:!self.singlePayment];
+    }
 }
 
 - (void)redirectToIndomaretPayment:(MidtransPaymentListModel *)paymentMethod {
@@ -441,7 +453,7 @@
 
 - (NSInteger)findPaymentMethodIndexInList:(NSArray *)paymentList forEnabledPayment:(MidtransPaymentRequestV2EnabledPayments *)enabledPayment {
     return [paymentList indexOfObjectPassingTest:^BOOL(id obj, NSUInteger idx, BOOL *stop) {
-        if (IPAD) {
+        if (IS_IPAD) {
             if ([enabledPayment.type isEqualToString:MIDTRANS_PAYMENT_QRIS] && enabledPayment.acquirer) {
                 self.qrisAcquirer = [NSString stringWithFormat:@"%@%@", enabledPayment.type, enabledPayment.acquirer];
                 return [obj[@"id"] isEqualToString:self.qrisAcquirer];


### PR DESCRIPTION
Fix issues where e-wallet can't be opened because of:
1. openURL is deprecated, need to update with the new implementation
2. IPAD UI_USER_INTERFACE_IDIOM() is also deprecated, need to updated with the new implementation 
3. update logic so that gopay and shopeepay app installation checker and deeplink can work properly.

App not installed:
![Simulator Screenshot - iPhone 16 Pro - 2025-02-03 at 16 02 53](https://github.com/user-attachments/assets/740dfe8d-a1e5-4a30-b77a-093b435c5704)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-03 at 16 03 08](https://github.com/user-attachments/assets/eda60168-1020-40e1-af29-fb50ec273472)



App opened ready for payment:
![IMG_5680](https://github.com/user-attachments/assets/c1de33c2-c3c8-406b-9b70-e388f68ebfb0)
![IMG_5681](https://github.com/user-attachments/assets/cfffe9d7-5d8d-4178-afb4-4bb029d4e93c)
![IMG_5678](https://github.com/user-attachments/assets/0e1ef28f-ec87-4f4e-9755-696170495ab5)
![IMG_5679](https://github.com/user-attachments/assets/38a2e954-e050-4298-8cf5-cddd0144d64f)
